### PR TITLE
Reworked error message printing (issue #2)

### DIFF
--- a/greedy.cpp
+++ b/greedy.cpp
@@ -86,7 +86,7 @@ int main()
     }
     catch (const std::invalid_argument &invalidArgumentException)
     {
-        std::cout << "User entered invalid value" << std::endl;
+        std::cout << invalidArgumentException.what();
     }
     
     return 0;


### PR DESCRIPTION
Now, if error appears, catched exception prints it's own error message:
```cpp
    catch (const std::invalid_argument &invalidArgumentException)
    {
        std::cout << invalidArgumentException.what() << std::endl;
    }
...
```